### PR TITLE
Moved pause command to 'M'

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -22,7 +22,7 @@
   * Task #5: Demonstrate changing player's field of view based on movement speed.
   
 ## User Story D
-  * Task #1: Demonstrate program accepting input from the 'escape' key. Points: 1
+  * Task #1: Demonstrate program accepting input from the 'M' key. Points: 1
   * Task #2: Demonstrate the ability to pause the program on keyboard input. Points: 5
   * Task #3: Demonstrate making a separate 'pause' window appear onscreen upon keyboard input.
   * Task #4: Demonstrate 'unpause' button that will appear on pause window.

--- a/features.md
+++ b/features.md
@@ -9,7 +9,7 @@
   a) As a Craft user, I want the player experience to feel more like actual minecraft, with camera bobbing to make movement       more fluid.
   b) As a Craft user, I want the player's field of view to change when sprinting in game to enhance the feel of sprinting.
 
-#3)Create a GUI on hitting ESCAPE so the player can pause the game, then select a resume button to resume or an exit button to leave the program
+#3)Create a GUI on hitting 'M' so the player can pause the game, then select a resume button to resume or an exit button to leave the program
   a) As a Craft user, I want to be able to pause my game of craft when I want to take a break.
   b) As a Craft user, I want to see a menu when I pause the game so that I can select to either resume or exit the game.
 

--- a/src/config.h
+++ b/src/config.h
@@ -43,6 +43,7 @@
 #define CRAFT_KEY_COMMAND '/'
 #define CRAFT_KEY_SIGN '`'
 #define CRAFT_KEY_AUTOWALK 'Q'
+#define CRAFT_KEY_PAUSEMENU 'M'
 
 // advanced parameters
 #define CREATE_CHUNK_RADIUS 10

--- a/src/main.c
+++ b/src/main.c
@@ -2209,7 +2209,6 @@ void on_key(GLFWwindow *window, int key, int scancode, int action, int mods) {
         }
         else if (exclusive) {
             glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL); //Set cursor back to normal.
-            start_pause(); //Pause all current operations in craft in preparation for showing the pause menu.
         }
     }
     if (key == GLFW_KEY_ENTER) {
@@ -2266,6 +2265,11 @@ void on_key(GLFWwindow *window, int key, int scancode, int action, int mods) {
                 g->isWalking = true;     
 			}
 		}
+        if(key == CRAFT_KEY_PAUSEMENU) {
+            printf("\'M\' was pressed!");
+            glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_NORMAL); //Set cursor back to normal.
+            start_pause(); //Pause all current operations in craft in preparation for showing the pause menu.
+        }
         if (key == CRAFT_KEY_FLY) {
             g->flying = !g->flying;
         }
@@ -2447,7 +2451,6 @@ void handle_movement(double dt) {
         if (glfwGetKey(g->window, GLFW_KEY_RIGHT)) s->rx += m;
         if (glfwGetKey(g->window, GLFW_KEY_UP)) s->ry += m;
         if (glfwGetKey(g->window, GLFW_KEY_DOWN)) s->ry -= m;
-        //if (glfwGetKey(g->window, GLFW_KEY_ESCAPE)) printf("Hello World!\n");
 	if (glfwGetKey(g->window, GLFW_KEY_G)) printf("G key was pressed\n");
     }
     float vx, vy, vz;


### PR DESCRIPTION
Pressing escape still releases the mouse like in the base version of craft.  Now pressing m pauses craft and releases the mouse.  This was done to keep the base functionality of pressing escape in tact.