### PR TITLE
Block Placement Saving Bug

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2149,6 +2149,7 @@ void on_left_click() {
         record_block(hx, hy, hz, 0);
         if (is_plant(get_block(hx, hy + 1, hz))) {
             set_block(hx, hy + 1, hz, 0);
+            record_block(hx, hy, hz, items[g->item_index]);
         }
     }
 }


### PR DESCRIPTION
Fixed bug where blocks being placed were not being saved when closing out and resuming the game. Deletions were saving but not placement. Now deletions and placements should both save and still exist when the game is reopened.